### PR TITLE
Unhardcode luncher icon path

### DIFF
--- a/data/desktop/pyakm.desktop
+++ b/data/desktop/pyakm.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Icon=/usr/share/pixmaps/pyakm.png
+Icon=pyakm
 Name=Arch Linux Kernel Manager
 Exec=pyakm-manager
 Terminal=false


### PR DESCRIPTION
Since the icon already is installed to `.../share/pixmaps`, a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path (neither the file type extension) in the launcher. 
The icon will be found anyway.

This facilitates icon theming.
Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.